### PR TITLE
fix(eng-1265): Return detail in toRFC8707 instead of title

### DIFF
--- a/src/errors/BasisTheoryReactorError.js
+++ b/src/errors/BasisTheoryReactorError.js
@@ -8,7 +8,7 @@ class BasisTheoryReactorError extends Error {
 
   toRFC7807() {
     return {
-      title: this.message,
+      detail: this.message,
       status: this.status,
       errors: this.validationErrors,
     };

--- a/tests/BasisTheoryReactorError.spec.js
+++ b/tests/BasisTheoryReactorError.spec.js
@@ -92,7 +92,7 @@ describe('BasisTheoryReactorError', () => {
       });
 
       expect(err.toRFC7807()).toMatchObject({
-        title: 'This is an error',
+        detail: 'This is an error',
         status: 400,
         errors: {
           property1: ['error 1', 'error 2'],


### PR DESCRIPTION
<!-- Describe your changes in detail -->

## Description

- Returns `detail` in toRFC8707 response object instead of `title`. Title is automatically set in our BasisTheory exception handler to the human-readable format of the HTTP Response Code.

<!-- Link to Linear Ticket Tracking if not automatically linked-->

### Linear Link

-

<!-- Describe impact to business or business use case -->

## Business Impact

- N/A

<!-- Please describe in detail how teammates can test your changes. -->

## Testing required outside of automated testing?

- [X] Not Applicable

<!-- Provide Screenshots when applicable -->

### Screenshots (if appropriate):

- [X] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->

## Rollback / Rollforward Procedure

- [X] Roll Forward
- [ ] Roll Back

<!-- Ensure that all related documentation on notion is updated -->

## Documentation
N/A

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of Business Impact.
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
