### PR TITLE
fix: publish to npm via OIDC (Node 20, npm publish --provenance)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,9 @@ jobs:
 
       # Only publish when semantic-release actually cut a release (version bumped);
       # never on chore/no-release pushes, so npm can't get an un-gated version.
-      - name: Publish to npm (OIDC trusted publishing)
+      - name: Publish to npm
+        if: steps.release.outputs.new_release_published == 'true'
+        run: npm publish --provenance --access public
         if: steps.release.outputs.published == 'true'
         run: npm publish --provenance --access public
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,23 @@ jobs:
         run: make verify
 
       - name: Release
-        run: make release
+        id: release
+        run: |
+          before="$(node -p "require('./package.json').version")"
+          make release
+          after="$(node -p "require('./package.json').version")"
+          if [ "$before" != "$after" ]; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # Only publish when semantic-release actually cut a release (version bumped);
+      # never on chore/no-release pushes, so npm can't get an un-gated version.
       - name: Publish to npm (OIDC trusted publishing)
+        if: steps.release.outputs.published == 'true'
         run: npm publish --provenance --access public
 
       - name: Stop Deploy Message

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,6 @@ jobs:
       # Only publish when semantic-release actually cut a release (version bumped);
       # never on chore/no-release pushes, so npm can't get an un-gated version.
       - name: Publish to npm
-        if: steps.release.outputs.new_release_published == 'true'
-        run: npm publish --provenance --access public
         if: steps.release.outputs.published == 'true'
         run: npm publish --provenance --access public
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ jobs:
   build-release:
     environment: PROD
     runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write # npm OIDC trusted publishing
+      contents: read
     strategy:
       matrix:
         node: ['20.x']
@@ -15,7 +18,6 @@ jobs:
     env:
       CI: 1
       HUSKY: 0 # disables husky hooks
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
 
       - name: Mint semantic-release app token
@@ -34,13 +36,16 @@ jobs:
           channel: ${{ vars.SLACK_DUCKBOT_RELEASE_CHANNEL_ID }}
 
       - name: Checkout repo
-        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e # v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ matrix.node }}
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@11.18.0 # npm >= 11.5.1 required for OIDC
 
       - name: Install deps (with cache)
         uses: bahmutov/npm-install@20216767ca67f0f7b4d095dc5859c5700a6581cb # v1
@@ -54,6 +59,9 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Publish to npm (OIDC trusted publishing)
+        run: npm publish --provenance --access public
 
       - name: Stop Deploy Message
         if: always()

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,12 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": false
+      }
+    ],
     "@semantic-release/github",
     [
       "@semantic-release/git",


### PR DESCRIPTION
## Description
- The release was failing with `EINVALIDNPMTOKEN Invalid npm token` — this repo still published via `NPM_TOKEN`. Switch it to npm **OIDC trusted publishing**, but **kept on Node 20** to match the `basistheory-reactor-functions` runtime.
- OIDC does not require Node 22 — that floor only comes from `@semantic-release/npm@13`. Instead (the `basis-theory-js` pattern): set `@semantic-release/npm` to `npmPublish: false` (version bump + changelog only, **no npm token required**), and do the publish via a dedicated `npm publish --provenance --access public` step using a global `npm@11.18.0` (npm ≥ 11.5.1 supports OIDC on Node 20.17+).
- Workflow: add `permissions: id-token: write`, upgrade npm to 11.18.0, modernize `checkout`/`setup-node` to v4 (reliable Node 20.17+ resolution), and **drop `NPM_TOKEN`**. Semantic-release stack unchanged (no dependency/lockfile churn). App token stays scoped to checkout + git write-back.
- Part of ENG-11425.

## Business Impact
- Minimal

## Testing required outside of automated testing?
- [x] Not Applicable

### Screenshots (if appropriate):
- [x] Not Applicable

## Rollback / Rollforward Procedure
- [x] Roll Forward
- [ ] Roll Back

## Documentation
[Link to docs if applicable, or leave empty]

## Reviewer Checklist
- [ ] Description of Change
- [ ] Description of Business Impact
- [ ] Description of outside testing if applicable
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change